### PR TITLE
Add missing socket, update dependencies, fix bug

### DIFF
--- a/load_selected_file_dolphin.patch
+++ b/load_selected_file_dolphin.patch
@@ -1,0 +1,63 @@
+From fcd7227e964faba5bfaacab5cc429d0e5f4603fd Mon Sep 17 00:00:00 2001
+From: Lukas Spies <Lukas@previewqt.org>
+Date: Thu, 8 May 2025 21:14:36 +0200
+Subject: [PATCH] [PQCSpecialActions] fix getting currently selected file from
+ dolphin, add more debug statements
+
+---
+ cplusplus/other/pqc_specialactions.cpp | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/cplusplus/other/pqc_specialactions.cpp b/cplusplus/other/pqc_specialactions.cpp
+index cff5f05..cd5b4d5 100644
+--- a/cplusplus/other/pqc_specialactions.cpp
++++ b/cplusplus/other/pqc_specialactions.cpp
+@@ -151,7 +151,9 @@ QString PQCSpecialActions::getSelectedFile_dolphin() {
+     // 2. Backup current clipboard interface
+ 
+     QString backupClipboard = clipboardGet();
+-    clipboardSet(" ");
++
++    // Note: Don't set a temporary (e.g., empty) clipboard content!
++    // It might make retrieving the file copied by dolphin impossible to retrieve.
+ 
+     /******************************************************************/
+     // 3. Prompt dolphin to copy selected location to clipboard
+@@ -183,6 +185,7 @@ QString PQCSpecialActions::getSelectedFile_dolphin() {
+ 
+     QString ret = clipboardGet();
+     if(!QFileInfo(ret).isFile()) {
++        qDebug() << "Failed to read copied file from clipboard";
+         clipboardSet(backupClipboard);
+         return "";
+     }
+@@ -190,6 +193,7 @@ QString PQCSpecialActions::getSelectedFile_dolphin() {
+     /******************************************************************/
+     // 5. Reset previous clipboard content
+ 
++    qDebug() << "Successfully read copied file from clipboard:" << ret;
+     clipboardSet(backupClipboard);
+ 
+     /******************************************************************/
+@@ -207,12 +211,17 @@ QString PQCSpecialActions::clipboardGet() {
+ 
+     if(klipperInterface.isValid()) {
+ 
++        qDebug() << "Valid response received from klipper";
++
+         // Calling the getClipboardContents method
+         QDBusReply<QString> reply = klipperInterface.call("getClipboardContents");
+ 
+         // Checking if the call was successful
+-        if(reply.isValid())
++        if(reply.isValid()) {
++            qDebug() << "Received valid klipper reply:" << reply;
+             return reply.value();
++        } else
++            qDebug() << "Invalid klipper reply received:" << reply;
+ 
+     }
+ 
+-- 
+GitLab
+

--- a/org.previewqt.PreviewQt.yml
+++ b/org.previewqt.PreviewQt.yml
@@ -13,7 +13,7 @@ finish-args:
     - --device=dri
     - --socket=pulseaudio
     - --talk-name=org.kde.StatusNotifierWatcher
-    - --socker=session-bus
+    - --socket=session-bus
     - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
     - --env=QML_IMPORT_PATH=/app/qml
 add-extensions:

--- a/org.previewqt.PreviewQt.yml
+++ b/org.previewqt.PreviewQt.yml
@@ -13,6 +13,7 @@ finish-args:
     - --device=dri
     - --socket=pulseaudio
     - --talk-name=org.kde.StatusNotifierWatcher
+    - --socker=session-bus
     - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
     - --env=QML_IMPORT_PATH=/app/qml
 add-extensions:
@@ -65,8 +66,8 @@ modules:
       sources:
         - type: git
           url: https://github.com/LibRaw/LibRaw
-          commit: 261c18ca0f1f9b83a53947b77751050d90d18e67
-          tag: 0.21.3
+          commit: 9646d776c7c61976080a8f2be67928df0750493e
+          tag: 0.21.4
         - type: shell
           commands:
             - "autoreconf -vfi"
@@ -101,8 +102,8 @@ modules:
       sources:
         - type: git
           url: https://github.com/AcademySoftwareFoundation/openexr
-          commit: 55d1a1404cec5b4b187009d9f7fe55a5622ac4e5
-          tag: v3.3.2
+          commit: da760aa4b6bee4b9d74b8c6a151221b035fc47b7
+          tag: v3.3.3
 
     ########################
     # POPPLER DOCUMENTS
@@ -127,8 +128,8 @@ modules:
         - ./b2 install variant=release link=shared runtime-link=shared --prefix="$FLATPAK_DEST" -j $FLATPAK_BUILDER_N_JOBS
       sources:
         - type: archive
-          url: https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
-          sha256: f55c340aa49763b1925ccf02b2e83f35fdcf634c9d5164a2acb87540173c741d
+          url: https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
+          sha256: 3621533e820dcab1e8012afd583c0c73cf0f77694952b81352bf38c1488f9cb4
     ########################
     - name: poppler
       buildsystem: cmake-ninja
@@ -147,8 +148,8 @@ modules:
       sources:
         - type: git
           url: https://gitlab.freedesktop.org/poppler/poppler
-          commit: 71fea5bed8a4c047c2063245ba1c5560b071ee25
-          tag: poppler-25.02.0
+          commit: 6dd9782d8391f112ef9743ba13614f1d858ce9f2
+          tag: poppler-25.05.0
 
     ########################
     # KDE IMAGE FORMATS
@@ -161,8 +162,8 @@ modules:
       sources:
         - type: git
           url: https://invent.kde.org/frameworks/extra-cmake-modules.git
-          commit: 7dd28cc56c339c3f8fb356f7c53c0e8f61433d81
-          tag: v6.10.0
+          commit: 1f820dc98d0a520c175433bcbb0098327d82aac6
+          tag: v6.13.0
     ########################
     - name: kimageformats
       buildsystem: cmake-ninja
@@ -175,8 +176,8 @@ modules:
       sources:
         - type: git
           url: https://invent.kde.org/frameworks/kimageformats.git
-          commit: f49704b2dfbfa5c5f892475254d114eab88dc833
-          tag: v6.10.0
+          commit: 6f588c6fd3b4345e5d697b4a3b28e7ea70576ead
+          tag: v6.13.0
 
     ########################
     # DEVIL IMAGE LIBRARY
@@ -201,8 +202,8 @@ modules:
         - --disable-static
       sources:
         - type: archive
-          url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10040/ghostscript-10.04.0.tar.gz
-          sha256: c764dfbb7b13fc71a7a05c634e014f9bb1fb83b899fe39efc0b6c3522a9998b1
+          url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10051/ghostscript-10.05.1.tar.gz
+          sha256: 121861b6d29b2461dec6575c9f3cab665b810bd408d4ec02c86719fa708b0a49
     ########################
     - name: imagemagick
       builddir: true
@@ -233,8 +234,8 @@ modules:
       sources:
         - type: git
           url: https://github.com/ImageMagick/ImageMagick
-          commit: a2d96f40e707ba54b57e7d98c3277d3ea6611ace
-          tag: 7.1.1-43
+          commit: 82572afc879b439cbf8c9c6f3a9ac7626adf98fb
+          tag: 7.1.1-47
 
     ########################
     ########################
@@ -262,3 +263,5 @@ modules:
           url: https://gitlab.com/lspies/previewqt.git
           tag: v4.0
           commit: 0e4eb21bacbef068e2472a71bf17baea5e4a7c12
+        - type: patch
+          path: load_selected_file_dolphin.patch

--- a/org.previewqt.PreviewQt.yml
+++ b/org.previewqt.PreviewQt.yml
@@ -12,8 +12,7 @@ finish-args:
     - --filesystem=host
     - --device=dri
     - --socket=pulseaudio
-    - --talk-name=org.kde.StatusNotifierWatcher
-    - --socket=session-bus
+    - --talk-name=org.kde.*
     - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
     - --env=QML_IMPORT_PATH=/app/qml
 add-extensions:


### PR DESCRIPTION
~This adds the `session-bus` as a new socket to the Flatpak. This socket is necessary for PreviewQt to be able to load a file that is only selected in Dolphin. What it does: It uses the DBUS API of Dolphin (and Klipper) to check if any supported file in a currently active Dolphin window is selected, and if it is it will request Dolphin to copy the path to the clipboard (using Klipper) which is then read by PreviewQt to load said file.~

~The only DBUS access that is needed is for Klipper and Dolphin, however, it appears that each window in Dolphin creates a new service called `org.kde.dolphin-xxx` with `xxx` the process id (afaict). It appears there is no way to allow access to a namespace including all subnames (e.g., allow access to `org.kde` which would allow for `org.kde.klipper` and `org.kde.dolphin-xxx`), or did I miss something somewhere?~

This adds `talk-name` for `org.kde.*` as PreviewQt needs to be able to talk to `org.kde.StatusNotifierWatcher` (as it did before already), `org.kde.klipper` and `org.kde.dolphin-xxx` where `xxx` is the respective process id of any one Dolphin window. PreviewQt needs access to all of them to check whether any one is currently the active window and, if so, copy any supported selected file to the clipboard. Dolphin provides a DBUS API for such functionality. As far as I'm aware, I can add a wildcard for a namespace as stated above, but I can't specify a wildcard for any suffix (i.e., just for the process ids for all Dolphin services), unless I missed something somewhere.

In additon to the new `talk-name`, dependencies have been updated and a small patch fixing clipboard handling in the flatpak build was added.